### PR TITLE
Changed event type to a site wide one.

### DIFF
--- a/classes/calendar/calendar.php
+++ b/classes/calendar/calendar.php
@@ -98,7 +98,7 @@ class calendar {
             'userid' => 0,
             'modulename' => '',
             'instance' => $outage->id,
-            'eventtype' => 'auth_outage',
+            'eventtype' => 'site',
             'timestart' => $outage->starttime,
             'visible' => true,
             'timeduration' => $outage->get_duration_planned(),


### PR DESCRIPTION
Moodle does not recognize `eventtype = 'auth_outage'` and therefore does not responds well in the calendar view to this event type. Since outage is site wide event I figured 'site' event type would be appropriate.